### PR TITLE
Rails 3.1 compatibility

### DIFF
--- a/lib/valid_attribute/matcher.rb
+++ b/lib/valid_attribute/matcher.rb
@@ -55,7 +55,7 @@ module ValidAttribute
       values.each do |value|
         subject.send("#{attr}=", value)
         subject.valid?
-        if subject.errors.key?(attr)
+        if subject.errors.include?(attr)
           self.failed_values << value
         else
           self.passed_values << value

--- a/spec/valid_attribute_spec.rb
+++ b/spec/valid_attribute_spec.rb
@@ -16,7 +16,7 @@ describe 'ValidAttribute' do
     context 'data is valid' do
       before do
         @user.stubs(:valid?).returns(true)
-        @user.stubs(:errors).returns({})
+        @user.stubs(:errors).returns(mock() { expects(:include?).twice.with(:name).returns(false) })
         @matcher = @should.have_valid(:name).when('abc', 123)
       end
 
@@ -39,7 +39,7 @@ describe 'ValidAttribute' do
     context 'data is invalid' do
       before do
         @user.stubs(:valid?).returns(false)
-        @user.stubs(:errors).returns({:name => []})
+        @user.stubs(:errors).returns(mock() { expects(:include?).twice.with(:name).returns(true) })
         @matcher = @should.have_valid(:name).when(:abc, nil)
       end
 
@@ -62,7 +62,7 @@ describe 'ValidAttribute' do
     context 'data is valid then invalid' do
       before do
         @user.stubs(:valid?).returns(true).then.returns(false)
-        @user.stubs(:errors).returns({}).then.returns({:name => []})
+        @user.stubs(:errors).returns(mock() { expects(:include?).at_most(2).with(:name).returns(false).then.returns(true) })
         @matcher = @should.have_valid(:name).when('abc', 123)
       end
 


### PR DESCRIPTION
Updated the matcher and corresponding specs so they no longer rely on ActiveModel::Errors inheriting from OrderedHash. This gets it working with Rails 3.1 and should be backwards compatible with 3.0.x. Tested against Rails 3.0.7 and 3.1.0.rc1.
