### PR TITLE
Gemfile: valid_attribute and rspec

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Supported ORMs
 
 ## Installation ##
 
-If you're using `RSpec` just add the `valid_attribute` to your `Gemfile`
+If you're using `RSpec` just add the `valid_attribute` to your `Gemfile` AFTER rspec gem.
 
 ```ruby
 gem 'valid_attribute'


### PR DESCRIPTION
If you add gem 'valid_attribute' before rspec gem the defined?(RSpec) will be nil but you still want to use RSpec.

Maybe the best option is use gem 'valid_attribute', :require => false
