### PR TITLE
Make .when optional

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,6 +63,9 @@ describe User do
     it { should have_valid(:password).when('password') }
     it { should_not have_valid(:password).when(nil) }
   end
+
+  # Using .when is optional. Without it, the existing value is examined.
+  it { should_not have_valid(:email) }
 end
 
 # TestUnit
@@ -80,6 +83,9 @@ class UserTest < Test::Unit::TestCase
     should have_valid(:password).when('password')
     should_not have_valid(:password).when(nil)
   end
+
+  # Using .when is optional. Without it, the existing value is examined.
+  should_not have_valid(:email)
 end
 ```
 

--- a/lib/valid_attribute/matcher.rb
+++ b/lib/valid_attribute/matcher.rb
@@ -44,23 +44,35 @@ module ValidAttribute
     private
 
     def check_values(subject)
-      unless values
-        raise ::ValidAttribute::NoValues, "you need to set the values with .when on the matcher. Example: have_valid(:name).when('Brian')"
-      end
-
       self.subject       = subject
       self.failed_values = []
       self.passed_values = []
 
-      values.each do |value|
-        subject.send("#{attr}=", value)
-        subject.valid?
+      if values
+        check_specified_values
+      else
+        check_existing_value
+      end
+    end
 
-        if invalid_attribute?(subject, attr)
-          self.failed_values << value
-        else
-          self.passed_values << value
-        end
+    def check_specified_values
+      values.each do |value|
+        check_value value
+      end
+    end
+
+    def check_existing_value
+      check_value subject.send("#{attr}")
+    end
+
+    def check_value(value)
+      subject.send("#{attr}=", value)
+      subject.valid?
+
+      if invalid_attribute?(subject, attr)
+        self.failed_values << value
+      else
+        self.passed_values << value
       end
     end
 

--- a/lib/valid_attribute/matcher.rb
+++ b/lib/valid_attribute/matcher.rb
@@ -21,9 +21,9 @@ module ValidAttribute
 
     def negative_failure_message
       if passed_values.size == 1
-        " expected #{subject.class}##{attr} to not accept the value: #{quote_values(passed_values)}"
+        " expected #{subject.class}##{attr} to reject the value: #{quote_values(passed_values)}"
       else
-        " expected #{subject.class}##{attr} to not accept the values: #{quote_values(passed_values)}"
+        " expected #{subject.class}##{attr} to reject the values: #{quote_values(passed_values)}"
       end
     end
 

--- a/spec/valid_attribute_spec.rb
+++ b/spec/valid_attribute_spec.rb
@@ -31,7 +31,7 @@ describe 'ValidAttribute' do
       describe 'messages' do
         it '#negative_failue_message' do
           @matcher.matches?(@user)
-          @matcher.negative_failure_message.should == " expected User#name to not accept the values: \"abc\", 123"
+          @matcher.negative_failure_message.should == " expected User#name to reject the values: \"abc\", 123"
         end
       end
     end
@@ -82,7 +82,7 @@ describe 'ValidAttribute' do
 
         it '#negative_failure_message' do
           @matcher.matches?(@user)
-          @matcher.negative_failure_message.should == " expected User#name to not accept the value: \"abc\""
+          @matcher.negative_failure_message.should == " expected User#name to reject the value: \"abc\""
         end
 
         it '#description' do

--- a/spec/valid_attribute_spec.rb
+++ b/spec/valid_attribute_spec.rb
@@ -90,13 +90,55 @@ describe 'ValidAttribute' do
         end
       end
     end
-  end
 
-  it 'requires .when to always be used' do
-    matcher = @should.have_valid(:name)
-    expect do
-      matcher.matches?(@user)
-    end.to raise_error ValidAttribute::NoValues, "you need to set the values with .when on the matcher. Example: have_valid(:name).when('Brian')"
+    context 'no values are specified with .when' do
+      context 'data is valid' do
+        before do
+          @user.stubs(:valid?).returns(true)
+          @user.stubs(:name).returns(:abc)
+          @matcher = @should.have_valid(:name)
+        end
+
+        it 'matches? returns true' do
+          @matcher.matches?(@user).should be_true
+        end
+
+        it 'does_not_match? returns false' do
+          @matcher.does_not_match?(@user).should be_false
+        end
+
+        describe 'messages' do
+          it '#negative_failue_message' do
+            @matcher.matches?(@user)
+            @matcher.negative_failure_message.should == " expected User#name to reject the value: :abc"
+          end
+        end
+      end
+
+      context 'data is invalid' do
+        before do
+          @user.stubs(:valid?).returns(false)
+          @user.stubs(:errors).returns({:name => ["can't be a symbol"]})
+          @user.stubs(:name).returns(:abc)
+          @matcher = @should.have_valid(:name)
+        end
+
+        it 'matches? returns false' do
+          @matcher.matches?(@user).should be_false
+        end
+
+        it 'does_not_match? returns true' do
+          @matcher.does_not_match?(@user).should be_true
+        end
+
+        describe 'messages' do
+          it '#failue_message' do
+            @matcher.matches?(@user)
+            @matcher.failure_message.should == " expected User#name to accept the value: :abc"
+          end
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
When I'm specing the boundaries of my validations, I like passing values to #when. Nice and clean. But sometimes I'd prefer to validate an existing object using whatever state it happens to contain, and in these cases .when is either redundant or nonsensical:

```
thing.should have_valid(:name)
thing.should_not have_valid(:name)
```

This is especially helpful after some operation that modifies attributes:

```
thing.strip_whitespace_from_attributes
thing.should have_valid(:email)
```

In this pull request, I've made #when optional, so have_valid can be used either way. Previously omitting when would raise an exception, but now the matcher uses the existing attribute. I also made a small tweak to wording, to change the phrase "expected foo to not accept the values" to "expected foo to reject the values".

Thanks for a nice, simple gem. I prefer it to "should validate..." style matchers. Test behavior.
