### PR TITLE
Better descriptions

### DIFF
--- a/lib/valid_attribute/matcher.rb
+++ b/lib/valid_attribute/matcher.rb
@@ -28,7 +28,7 @@ module ValidAttribute
     end
 
     def description
-      "be valid when: #{quote_values(values)}"
+      "be valid when #{attr} is: #{quote_values(values)}"
     end
 
     def matches?(subject)

--- a/spec/valid_attribute_spec.rb
+++ b/spec/valid_attribute_spec.rb
@@ -86,7 +86,7 @@ describe 'ValidAttribute' do
         end
 
         it '#description' do
-          @matcher.description.should == "be valid when: \"abc\", 123"
+          @matcher.description.should == "be valid when name is: \"abc\", 123"
         end
       end
     end


### PR DESCRIPTION
Hello, Brian,

I've changed the description a bit, because it didn't clearly show what attribute was being spec'd. For example:

```
describe Something
  it { should.have_valid(:name).when(:abc, 123) }
end
```

The message in this case looks something like:

```
Something
  should be valid when: "abc", 123
```

I'd definitely prefer to see this instead:

```
Something
  should be valid when name is: "abc", 123
```
