### PR TITLE
Add minitest support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,6 +36,17 @@ require 'shoulda-context'
 require 'valid_attribute'
 ```
 
+If you want to you use it with `MiniTest::Spec` you can use either `shoulda-context` (see above) or [minitest-matchers](https://github.com/zenspider/minitest-matchers):
+
+```ruby
+# Gemfile
+gem 'minitest-matchers'
+
+# test_helper.rb
+require 'minitest/matchers'
+require 'valid_attribute'
+```
+
 ## Usage ##
 
 Instead of having validation specific matchers `ValidAttribute` only cares if the attribute is valid under certain circumstances
@@ -88,6 +99,27 @@ class UserTest < Test::Unit::TestCase
 
   # Using .when is optional. Without it, the existing value is examined.
   should_not have_valid(:email)
+end
+
+# Minitest::Matchers
+require 'minitest/matchers'
+describe User do
+  subject { User.new }
+
+  # The .when method can take any number of values that you want to pass
+  must { have_valid(:email).when('test@test.com', 'test+spam@gmail.com') }
+  wont { have_valid(:email).when('fail', 123) }
+  must { have_valid(:name).when('TestName') }
+  wont { have_valid(:name).when('Test') }
+
+  describe 'password' do
+    subject { User.new(:password_confirmation => 'password') }
+    must {  have_valid(:password).when('password') }
+    wont {  have_valid(:password).when(nil) }
+  end
+
+  # Using .when is optional. Without it, the existing value is examined.
+  wont have_valid(:email)
 end
 ```
 

--- a/lib/valid_attribute.rb
+++ b/lib/valid_attribute.rb
@@ -7,6 +7,8 @@ end
 
 if defined?(RSpec)
   require 'valid_attribute/rspec'
+elsif defined?(MiniTest::Matchers)
+  require 'valid_attribute/minitest'
 else
   require 'valid_attribute/test_unit'
 end

--- a/lib/valid_attribute/minitest.rb
+++ b/lib/valid_attribute/minitest.rb
@@ -1,0 +1,3 @@
+class MiniTest::Spec
+  extend ::ValidAttribute::Method
+end

--- a/spec/minitest_spec.rb
+++ b/spec/minitest_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'minitest/spec'
+require 'valid_attribute/minitest'
+
+describe 'MiniTest::Spec' do
+  it '.have_valid' do
+    MiniTest::Spec.have_valid(:name).should be_instance_of(ValidAttribute::Matcher)
+  end
+end
+

--- a/valid_attribute.gemspec
+++ b/valid_attribute.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'bourne'
+  s.add_development_dependency 'minitest-matchers'
   if RUBY_VERSION >= '1.9'
     if RUBY_VERSION <= '1.9.2'
       s.add_development_dependency 'ruby-debug19'


### PR DESCRIPTION
minitest is a drop-in replacement for test/unit. It's already in 1.9 and Rails is using it when possible.
