### PR TITLE
rbx-2.0 is unknown to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - rbx
-  - rbx-2.0
+  - rbx-18mode
   - ree
   - jruby


### PR DESCRIPTION
rbx and rbx-2.0 are now both aliases for rbx-18mode
