### PR TITLE
Avoid "unitialized constant Test" error when not using test/unit

### DIFF
--- a/lib/valid_attribute/test_unit.rb
+++ b/lib/valid_attribute/test_unit.rb
@@ -1,3 +1,5 @@
+require 'test/unit'
+
 class Test::Unit::TestCase
   extend ::ValidAttribute::Method
 end


### PR DESCRIPTION
If you do not `require 'test/unit`, an "unitialized constant Test" error is raised.
