### PR TITLE
silence RSpec 3 warnings

### DIFF
--- a/lib/valid_attribute/matcher.rb
+++ b/lib/valid_attribute/matcher.rb
@@ -1,9 +1,11 @@
 module ValidAttribute
   class Matcher
-    attr_accessor :attr, :values, :subject, :failed_values, :passed_values
+    attr_accessor :attr, :subject, :failed_values, :passed_values
+    attr_writer :values
 
     def initialize(attr)
       self.attr = attr
+      @clone = nil
     end
 
     # The collection of values to test against for the given
@@ -24,6 +26,7 @@ module ValidAttribute
     def negative_failure_message
       message(passed_values, 'reject')
     end
+    alias failure_message_when_negated negative_failure_message
 
     def description
       "be valid when #{attr} is: #{quote_values(values)}"
@@ -67,10 +70,7 @@ module ValidAttribute
     end
 
     def values
-      unless @values
-        @values = [subject.send(attr)]
-      end
-      @values
+      @values ||= [subject.send(attr)]
     end
 
     def check_value(value)

--- a/spec/valid_attribute_spec.rb
+++ b/spec/valid_attribute_spec.rb
@@ -32,6 +32,7 @@ describe 'ValidAttribute' do
         it '#negative_failure_message' do
           @matcher.matches?(@user)
           @matcher.negative_failure_message.should == " expected User#name to reject the values: \"abc\", 123"
+          @matcher.failure_message_when_negated.should == @matcher.negative_failure_message
         end
       end
     end


### PR DESCRIPTION
Covers all the RSpec 3 warnings I've seen. Some were just regular Ruby warnings, but RSpec 3 is especially loud about them by default.

I left the old negative rspec matcher too. I can get rid of it if you have a preferred method for handling different versions of libraries.
