### PR TITLE
Add alias to Matcher for RSpec v3.0

### DIFF
--- a/lib/valid_attribute/matcher.rb
+++ b/lib/valid_attribute/matcher.rb
@@ -25,6 +25,8 @@ module ValidAttribute
       message(passed_values, 'reject')
     end
 
+    alias_method :failure_message_when_negated, :negative_failure_message
+
     def description
       "be valid when #{attr} is: #{quote_values(values)}"
     end


### PR DESCRIPTION
The following RSpec:

``` ruby
expect(registration).to have_valid(:social_security_number).when '123-45-6789', '123456789'
```

produces this warning when used with RSpec v3.0:

```
ValidAttribute::Matcher implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
```

This PR simply creates an alias to silence this warning.
