### PR TITLE
Adding license info to the gemspec.

### DIFF
--- a/valid_attribute.gemspec
+++ b/valid_attribute.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/bcardarella/valid_attribute'
   s.summary       = %q{Minimalist validation matcher}
   s.description   = %q{Minimalist validation matcher}
+  s.license       = 'MIT'
   s.files         = Dir['{lib}/**/*'] + ['README.md']
   s.require_paths = ['lib']
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.